### PR TITLE
Added support for Image component and dynamic import!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the "nextjs-snippets" extension will be documented in this file.
 
+## 0.0.4 - 2021/02/27
+
+### Added
+
+- Added import for Image component **`nii`** (_nextjs import Image_)
+- Added usage for Image component **`nui`** (_nextjs use Image_)
+
+- added import for dynamic **`nid`** (_nextjs import dynamic_)
+- added usage for dynamic **`nud`** (_nextjs use dynamic_)
+- added usage for dynamic with named exports **`nudwne`** (_nextjs use dynamic with named exports_)
+
 ## 0.0.3 - 2020/06/29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -590,3 +590,9 @@ import Head from 'next/head';
 ```javascriptreact
 import Image from 'next/image';
 ```
+
+### `nid` (nextjs import dynamic)
+
+```javascriptreact
+import dynamic from 'next/dynamic';
+```

--- a/README.md
+++ b/README.md
@@ -559,7 +559,6 @@ export const getStaticProps:GetStaticProps = async (ctx) => {
 export default FileName;
 ```
 
-
 ## Importing Components
 
 ### `nil` (nextjs import link)
@@ -584,4 +583,10 @@ import {useRouter} from 'next/router';
 
 ```javascriptreact
 import Head from 'next/head';
+```
+
+### `nii` (nextjs import Image)
+
+```javascriptreact
+import Image from 'next/image';
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nextjs-snippets",
   "displayName": "Next.js snippets",
   "description": "snippets for nextjs",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "engines": {
     "vscode": "^1.46.0"
   },

--- a/snippets/JavascriptReact/nextjs.code-snippets
+++ b/snippets/JavascriptReact/nextjs.code-snippets
@@ -344,6 +344,11 @@
     "body": ["import ${1:Image} from 'next/image';"],
     "description": "next import Image"
   },
+  "Nextjs import for Dynamic": {
+    "prefix": "nid",
+    "body": ["import ${1:dynamic} from 'next/dynamic';"],
+    "description": "next import dynamic"
+  },
 
   // nextjs imported components usage
   "Nextjs link component defination with href": {

--- a/snippets/JavascriptReact/nextjs.code-snippets
+++ b/snippets/JavascriptReact/nextjs.code-snippets
@@ -372,5 +372,10 @@
     "prefix": "nuh",
     "body": ["<Head>", "\t<title>${1:Title}</title>", "</Head>"],
     "description": "nextjs usage of Head Component"
+  },
+  "Nextjs Image component defination": {
+    "prefix": "nui",
+    "body": ["<Image src='${1:path}' width='' height='' alt='' />"],
+    "description": "nextjs usage of Image Component"
   }
 }

--- a/snippets/JavascriptReact/nextjs.code-snippets
+++ b/snippets/JavascriptReact/nextjs.code-snippets
@@ -377,5 +377,10 @@
     "prefix": "nui",
     "body": ["<Image src='${1:path}' width='' height='' alt='' />"],
     "description": "nextjs usage of Image Component"
+  },
+  "Nextjs Dynamic Import defination": {
+    "prefix": "nud",
+    "body": ["const ${1:DynamicComponent} = dynamic(() => import('${2:./path}'))"],
+    "description": "nextjs usage of Dynamic Import"
   }
 }

--- a/snippets/JavascriptReact/nextjs.code-snippets
+++ b/snippets/JavascriptReact/nextjs.code-snippets
@@ -319,10 +319,10 @@
   },
 
   // import next components
-  "Nextjs import for link component": {
+  "Nextjs import for Link component": {
     "prefix": "nil",
     "body": ["import ${1:Link} from 'next/link';"],
-    "description": "next import link"
+    "description": "next import Link"
   },
   "Nextjs import for Router(default) component": {
     "prefix": "nir",
@@ -334,14 +334,18 @@
     "body": ["import {useRouter} from 'next/router';"],
     "description": "next import useRouter"
   },
-  "Nextjs import for head component": {
+  "Nextjs import for Head component": {
     "prefix": "nih",
     "body": ["import ${1:Head} from 'next/head';"],
     "description": "next import Head"
   },
+  "Nextjs import for Image component": {
+    "prefix": "nii",
+    "body": ["import ${1:Image} from 'next/image';"],
+    "description": "next import Image"
+  },
 
   // nextjs imported components usage
-
   "Nextjs link component defination with href": {
     "prefix": "nulwhref",
     "body": ["<Link href='${1:path}'><a>${2:value}</a></Link>"],

--- a/snippets/JavascriptReact/nextjs.code-snippets
+++ b/snippets/JavascriptReact/nextjs.code-snippets
@@ -382,5 +382,10 @@
     "prefix": "nud",
     "body": ["const ${1:DynamicComponent} = dynamic(() => import('${2:./path}'))"],
     "description": "nextjs usage of Dynamic Import"
-  }
+  },
+  "Nextjs Dynamic Import defination with named exports": {
+    "prefix": "nudwne",
+    "body": ["const ${1:DynamicComponent} = dynamic(() =>", "\timport('${2:./path}').then((mod) => mod.${1:DynamicComponent})", ")"],
+    "description": "nextjs usage of Dynamic Import with named exports"
+  },
 }

--- a/snippets/TypescriptReact/nextjs.code-snippets
+++ b/snippets/TypescriptReact/nextjs.code-snippets
@@ -175,6 +175,11 @@
     "body": ["import ${1:Image} from 'next/image';"],
     "description": "next import Image"
   },
+  "Nextjs import for Dynamic": {
+    "prefix": "nid",
+    "body": ["import ${1:dynamic} from 'next/dynamic';"],
+    "description": "next import dynamic"
+  },
 
   // api routes
   "Nextjs Api route": {

--- a/snippets/TypescriptReact/nextjs.code-snippets
+++ b/snippets/TypescriptReact/nextjs.code-snippets
@@ -148,11 +148,12 @@
       "export default ${TM_FILENAME_BASE};"
     ]
   },
+  
   // import next components
-  "Nextjs import for link component": {
+  "Nextjs import for Link component": {
     "prefix": "nil",
     "body": ["import ${1:Link} from 'next/link';"],
-    "description": "next import link"
+    "description": "next import Link"
   },
   "Nextjs import for Router(default) component": {
     "prefix": "nir",
@@ -164,10 +165,15 @@
     "body": ["import {useRouter} from 'next/router';"],
     "description": "next import useRouter"
   },
-  "Nextjs import for head component": {
+  "Nextjs import for Head component": {
     "prefix": "nih",
     "body": ["import ${1:Head} from 'next/head';"],
     "description": "next import Head"
+  },
+  "Nextjs import for Image component": {
+    "prefix": "nii",
+    "body": ["import ${1:Image} from 'next/image';"],
+    "description": "next import Image"
   },
 
   // api routes


### PR DESCRIPTION
- Added import for Image component **`nii`** (_nextjs import Image_)
- Added usage for Image component **`nui`** (_nextjs use Image_)

- added import for dynamic **`nid`** (_nextjs import dynamic_)
- added usage for dynamic **`nud`** (_nextjs use dynamic_)
- added usage for dynamic with named exports **`nudwne`** (_nextjs use dynamic with named exports_)

[learn more about Image Component](https://nextjs.org/docs/api-reference/next/image)
[learn more about Dynamic Import](https://nextjs.org/docs/advanced-features/dynamic-import)